### PR TITLE
Correction for accessing clean trait and community data from osf

### DIFF
--- a/data_paper/1_download_clean_data.R
+++ b/data_paper/1_download_clean_data.R
@@ -4,16 +4,16 @@ library("dataDownloader")
 
 #Download community data from OSF
 get_file(node = "gs8u6",
-         file = "PFTC3-Puna-PFTC5_Peru_2018-2020_CommunityCover_clean.cs",
+         file = "PFTC3-Puna-PFTC5_Peru_2018-2020_CommunityCover_clean.csv",
          path = "clean_data",
-         remote_path = "Community")
+         remote_path = "community")
 
 
 #Download traits data from OSF
 get_file(node = "gs8u6",
          file = "PFTC3-Puna-PFTC5_Peru_2018-2020_LeafTraits_clean.csv",
          path = "clean_data",
-         remote_path = "Traits")
+         remote_path = "traits")
 
 
 #Download climate data from OSF


### PR DESCRIPTION
made changes to remote path (made all lowercase) and the 'v' in csv. was missing for community. This runs and downloads on my machine at least - did not previously