### PR TITLE
Some figure aesthetic changes + 1 data download 

### DIFF
--- a/data_paper/1_download_clean_data.R
+++ b/data_paper/1_download_clean_data.R
@@ -17,11 +17,17 @@ get_file(node = "gs8u6",
          path = "clean_data",
          remote_path = "traits")
 
-#Download traits data from OSF
+#Download biomass data from OSF
 get_file(node = "gs8u6",
          file = "Puna_Peru_2019_Biomass_clean.csv",
          path = "clean_data",
          remote_path = "biomass")
+
+#Download community structure data from OSF
+get_file(node = "gs8u6",
+         file = "PFTC3-Puna-Peru_2018-2019_CommunityStructure_clean.csv",
+         path = "clean_data",
+         remote_path = "community")
 
 #Download climate data from OSF
 # get_file(node = "gs8u6",

--- a/data_paper/1_download_clean_data.R
+++ b/data_paper/1_download_clean_data.R
@@ -23,12 +23,6 @@ get_file(node = "gs8u6",
          path = "clean_data",
          remote_path = "biomass")
 
-#Download community structure data from OSF
-get_file(node = "gs8u6",
-         file = "PFTC3-Puna-Peru_2018-2019_CommunityStructure_clean.csv",
-         path = "clean_data",
-         remote_path = "community")
-
 #Download climate data from OSF
 # get_file(node = "gs8u6",
 #          file = "China_2013_2016_AirTemp.csv",

--- a/data_paper/puna_colour_palette.R
+++ b/data_paper/puna_colour_palette.R
@@ -25,4 +25,9 @@ puna_treatment_colour = puna_colour %>%
          treatment == "BB") %>%
   select(-site)
 
+#To capitalise labels
+capitalise <- function(string) {
+  substr(string, 1, 1) <- toupper(substr(string, 1, 1))
+  string
+}
 


### PR DESCRIPTION
So I was playing a bit with the figures 9because I have no impulse control when it comes to these things)

One thing I picked up is that in `data_paper_1_download_clean_data.R` there wasn't a call to retrieve the clean community structure dataset from _osf_ I'm assuming this might just be because the dataset is clean but not complete (i.e. waiting on 2020) but I add it in just in case a gremlin came in and removed it

Regarding figures a tweaked things here and there - I guess there will be things you vibe with and things you don't feel free to cherry pick (if at all):

Gradients:
![Gradient_plot](https://user-images.githubusercontent.com/61696728/117108336-4f701a80-ad83-11eb-81af-a0ea821d2f02.jpeg)
I changed to fill of the CI bands, removed the fill from the legend keys and capitalised the legend title

NMDS:
![NMDS_ordination](https://user-images.githubusercontent.com/61696728/117108431-7595ba80-ad83-11eb-8118-79ab98719dbc.jpeg)
Changed the symbols for treatments so C is the only 'filled' one ☝️ I did not capitalise these legend titles though 🙈 

Trait Distribution
![Trait_distribution](https://user-images.githubusercontent.com/61696728/117108546-a675ef80-ad83-11eb-904d-fe5f590e5e49.jpeg)
Possibly not going to go down well but changed the line colour to match site (Even I'm on the fence on this as a design choice), parsed the labels so that they don't have underscores and capitalised legend title

Trait check
![Trait_checks](https://user-images.githubusercontent.com/61696728/117108695-d9b87e80-ad83-11eb-9a33-459b0c2b9dd4.jpeg)
Only legend title I think...
